### PR TITLE
Localised time

### DIFF
--- a/app/commands/all_commands.js
+++ b/app/commands/all_commands.js
@@ -48,7 +48,7 @@ const DICE_COMMAND = {
 
 const LOCALISED_TIME_COMMAND = {
     name: 'localised_time',
-    description: 'Provides a discord-friendly (unix) localised time from a command to save you going and getting it from some external site.',
+    description: 'Provides a localised time',
     type: 1,
     integration_types: [0, 1],
     contexts: [0, 1, 2],
@@ -56,7 +56,7 @@ const LOCALISED_TIME_COMMAND = {
         {
             name: 'datetime',
             type: 3, // String
-            description: 'Enter the datetime in this format: HH:mm dd/MM/yyyy',
+            description: 'Enter the datetime in this format: `yyyy-MM-ddTHH:mm:ss`',
             required: false
         }
     ]

--- a/app/commands/all_commands.js
+++ b/app/commands/all_commands.js
@@ -54,10 +54,22 @@ const LOCALISED_TIME_COMMAND = {
     contexts: [0, 1, 2],
     options: [
         {
-            name: 'datetime',
+            name: 'date',
             type: 3, // String
-            description: 'Enter the datetime in this format: `yyyy-MM-ddTHH:mm:ss`',
-            required: false
+            description: 'Enter the date in `yyyy-MM-dd` format',
+            required: true
+        },
+        {
+            name: 'time',
+            type: 3, // String
+            description: 'Enter time in `HH:mm` (24h) format',
+            required: true
+        },
+        {
+            name: 'timezone',
+            type: 3, // String
+            description: 'Enter the timezone in `<+/->HH:mm` format, e.g. `+01:00`',
+            required: true
         }
     ]
 }

--- a/app/commands/all_commands.js
+++ b/app/commands/all_commands.js
@@ -46,12 +46,29 @@ const DICE_COMMAND = {
     ]
 }
 
-const ALL_COMMANDS = [TEST_COMMAND, QUOTE_COMMAND, DICE_COMMAND];
+const LOCALISED_TIME_COMMAND = {
+    name: 'localised_time',
+    description: 'Provides a discord-friendly (unix) localised time from a command to save you going and getting it from some external site.',
+    type: 1,
+    integration_types: [0, 1],
+    contexts: [0, 1, 2],
+    options: [
+        {
+            name: 'datetime',
+            type: 3, // String
+            description: 'Enter the datetime in this format: HH:mm dd/MM/yyyy',
+            required: false
+        }
+    ]
+}
+
+const ALL_COMMANDS = [TEST_COMMAND, QUOTE_COMMAND, DICE_COMMAND, LOCALISED_TIME_COMMAND];
 
 InstallGlobalCommands(process.env.APP_ID, ALL_COMMANDS);
 
 export const COMMANDS = Object.freeze({
     TEST: TEST_COMMAND.name,
     QUOTE: QUOTE_COMMAND.name,
-    DICE: DICE_COMMAND.name
+    DICE: DICE_COMMAND.name,
+    LOCALISED_TIME: LOCALISED_TIME_COMMAND.name
 });

--- a/app/commands/command_handler.js
+++ b/app/commands/command_handler.js
@@ -2,6 +2,7 @@ import { InteractionResponseType } from "discord-interactions";
 import { COMMANDS } from "./all_commands.js";
 import { getShunQuote } from "./command_shunquote_handler.js";
 import { diceRollHandler } from "./command_dice_handler.js";
+import { getLocalisedTime } from "./command_localised_time.js";
 
 export async function handleCommand(data, res) {
     const { name } = data;
@@ -24,6 +25,13 @@ export async function handleCommand(data, res) {
         case COMMANDS.DICE:
             const [{ value : diceToRoll }] = options;
             message = `Rolling ${diceToRoll}... It's: ` + diceRollHandler(diceToRoll);
+            return res.send({
+                type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+                data: { content: message }
+            });
+        case COMMANDS.LOCALISED_TIME:
+            const [{ value : dateTime }] = options;
+            message = getLocalisedTime(dateTime);
             return res.send({
                 type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
                 data: { content: message }

--- a/app/commands/command_handler.js
+++ b/app/commands/command_handler.js
@@ -30,8 +30,8 @@ export async function handleCommand(data, res) {
                 data: { content: message }
             });
         case COMMANDS.LOCALISED_TIME:
-            const [{ value : dateTime }] = options;
-            message = getLocalisedTime(dateTime);
+            const [{ value : date }, { value : time }, { value : timezone }] = options;
+            message = getLocalisedTime(date, time, timezone);
             return res.send({
                 type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
                 data: { content: message }

--- a/app/commands/command_localised_time.js
+++ b/app/commands/command_localised_time.js
@@ -1,9 +1,35 @@
 export function getLocalisedTime(date, time, timezone) {
-    return `<t:${getUnixTimeInSeconds(date, time, timezone)}:F>`;
+    let formattedDateTime;
+    try {
+        formattedDateTime = formatDateTime(date, time, timezone);
+    } catch (error) {
+        return error;
+    }
+
+    return `<t:${getUnixTimeInSeconds(formattedDateTime)}:F>`;
 }
 
-function getUnixTimeInSeconds(date, time, timezone) { 
-    const dateTime = `${date}T${time}${timezone}`;
-    const outputDate = new Date(dateTime);
-    return Math.floor(outputDate.getTime() / 1000);
+function formatDateTime(date, time, timezone) {
+    validateDateTimeFormat(date, time, timezone);
+    return `${date}T${time}${timezone}`;
+}
+
+function validateDateTimeFormat(date, time, timezone) {
+    const dateFormatRegex = /^\d{4}\-(0[1-9]|1[012])\-(0[1-9]|[12][0-9]|3[01])$/;
+    const timeFormatRegex = /^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$/;
+    const timezoneFormatRegex = /^[+-]((0[0-9]|1[0-1]):[0-5][0-9])|12:00$/;
+
+    // if date, time and timezone are not in the right format
+    if (!dateFormatRegex.test(date)) {
+        throw "Date in incorrect format";
+    } else if (!timeFormatRegex.test(time)) {
+        throw "Time in incorrect format";
+    } else if (!timezoneFormatRegex.test(timezone)) {
+        throw "Timezone in incorrect format";
+    }
+}
+
+function getUnixTimeInSeconds(formattedDateTime) { 
+    const date = new Date(formattedDateTime);
+    return Math.floor(date.getTime() / 1000);
 }

--- a/app/commands/command_localised_time.js
+++ b/app/commands/command_localised_time.js
@@ -1,35 +1,15 @@
+import { 
+    getFormattedDateTimeString,
+    getUnixTimeInSeconds,
+} from "../utils/time_tools.js";
+
 export function getLocalisedTime(date, time, timezone) {
     let formattedDateTime;
     try {
-        formattedDateTime = formatDateTime(date, time, timezone);
+        formattedDateTime = getFormattedDateTimeString(date, time, timezone);
     } catch (error) {
         return error;
     }
 
     return `<t:${getUnixTimeInSeconds(formattedDateTime)}:F>`;
-}
-
-function formatDateTime(date, time, timezone) {
-    validateDateTimeFormat(date, time, timezone);
-    return `${date}T${time}${timezone}`;
-}
-
-function validateDateTimeFormat(date, time, timezone) {
-    const dateFormatRegex = /^\d{4}\-(0[1-9]|1[012])\-(0[1-9]|[12][0-9]|3[01])$/;
-    const timeFormatRegex = /^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$/;
-    const timezoneFormatRegex = /^[+-]((0[0-9]|1[0-1]):[0-5][0-9])|12:00$/;
-
-    // if date, time and timezone are not in the right format
-    if (!dateFormatRegex.test(date)) {
-        throw "Date in incorrect format";
-    } else if (!timeFormatRegex.test(time)) {
-        throw "Time in incorrect format";
-    } else if (!timezoneFormatRegex.test(timezone)) {
-        throw "Timezone in incorrect format";
-    }
-}
-
-function getUnixTimeInSeconds(formattedDateTime) { 
-    const date = new Date(formattedDateTime);
-    return Math.floor(date.getTime() / 1000);
 }

--- a/app/commands/command_localised_time.js
+++ b/app/commands/command_localised_time.js
@@ -1,8 +1,9 @@
-export function getLocalisedTime(dateTime) {
-    return `<t:${getUnixTimeInSeconds(dateTime)}:F>`;
+export function getLocalisedTime(date, time, timezone) {
+    return `<t:${getUnixTimeInSeconds(date, time, timezone)}:F>`;
 }
 
-function getUnixTimeInSeconds(dateTime) { 
-    const date = new Date(dateTime);
-    return Math.floor(date.getTime() / 1000);
+function getUnixTimeInSeconds(date, time, timezone) { 
+    const dateTime = `${date}T${time}${timezone}`;
+    const outputDate = new Date(dateTime);
+    return Math.floor(outputDate.getTime() / 1000);
 }

--- a/app/commands/command_localised_time.js
+++ b/app/commands/command_localised_time.js
@@ -1,0 +1,8 @@
+export function getLocalisedTime(dateTime) {
+    return `<t:${getUnixTimeInSeconds(dateTime)}:F>`;
+}
+
+function getUnixTimeInSeconds(dateTime) { 
+    const date = new Date(dateTime);
+    return Math.floor(date.getTime() / 1000);
+}

--- a/app/utils/time_tools.js
+++ b/app/utils/time_tools.js
@@ -1,0 +1,23 @@
+export function getFormattedDateTimeString(date, time, timezone) {
+    validateDateTimeFormat(date, time, timezone);
+    return `${date}T${time}${timezone}`;
+}
+
+function validateDateTimeFormat(date, time, timezone) {
+    const dateFormatRegex = /^\d{4}\-(0[1-9]|1[012])\-(0[1-9]|[12][0-9]|3[01])$/;
+    const timeFormatRegex = /^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$/;
+    const timezoneFormatRegex = /^[+-]((0[0-9]|1[0-1]):[0-5][0-9])|12:00$/;
+
+    if (!dateFormatRegex.test(date)) {
+        throw "Date in incorrect format";
+    } else if (!timeFormatRegex.test(time)) {
+        throw "Time in incorrect format";
+    } else if (!timezoneFormatRegex.test(timezone)) {
+        throw "Timezone in incorrect format";
+    }
+}
+
+export function getUnixTimeInSeconds(formattedDateTime) { 
+    const date = new Date(formattedDateTime);
+    return Math.floor(date.getTime() / 1000);
+}


### PR DESCRIPTION
# Description
<!-- Add a description here -->
Leaving this as draft right now as there's more to do, but so far we have: 
- Added support for the new command and its parameters
- Added time tools to convert input fields into an acceptable time object, with error handling 
- formatted this to a unix time and formatted that unix time to a discord-readable unix time format 

Still to-do: 
- Add support for time zone identifiers (`GMT`, `CEST`, etc) alongside the existing `+/-HH:MM` manual entry. Do all mapping associated with this. 
- Update the README 
- Investigate error handling - see if there's a way to make it so that the bot won't send the message if there are errors, but display them only to the user who is sending the request 

# Screenshots / Videos
<!-- If applicable, please add/remove -->
